### PR TITLE
Init implementation of lock logic

### DIFF
--- a/Othello/AppModel/AppFlow.cs
+++ b/Othello/AppModel/AppFlow.cs
@@ -15,6 +15,8 @@ public abstract class AppFlow : IAppControl, IView
 	protected DateTime LastMoveDateTime;
 	protected Timer AutoMoveOnTimer;
 	protected List<(int, int)> CurrentGameMoves = new List<(int, int)>();
+	protected bool Locked = false;
+	protected object Lock = new object(); 
 
 
 	protected AppFlow(IViewApp viewApp, IMoveProvider moveProvider, ICoordinatesTranslator coordinatesTranslator)


### PR DESCRIPTION
Initial implementation of lock logic to ensure critical processes are not interrupted during execution by timer if timer is irrelevant by process flow logic